### PR TITLE
Add problem upload service

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -16,3 +16,9 @@ mode = "debug"
 
 [judger]
 host = "http://localhost:8000"
+
+[minio]
+endpoint = "localhost:9000"
+accessKeyID = "minio-root-user"
+secretAccessKey = "minio-root-password"
+useSSL = false

--- a/config/development.toml
+++ b/config/development.toml
@@ -22,3 +22,4 @@ endpoint = "localhost:9000"
 accessKeyID = "minio-root-user"
 secretAccessKey = "minio-root-password"
 useSSL = false
+bucketName = "oj-lab-problem-packages"

--- a/packages/application/minio.go
+++ b/packages/application/minio.go
@@ -1,0 +1,47 @@
+package application
+
+import (
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+const (
+	minioEndpointProp        = "minio.endpoint"
+	minioAccessKeyProp       = "minio.accessKeyID"
+	minioSecretAccessKeyProp = "minio.secretAccessKey"
+	minioUseSSLProp          = "minio.useSSL"
+	minioRegionProp          = "minio.region"
+)
+
+var (
+	endpoint        string
+	accessKeyID     string
+	secretAccessKey string
+	useSSL          bool
+	region          string
+	minioClient     *minio.Client
+)
+
+func init() {
+	endpoint = AppConfig.GetString(minioEndpointProp)
+	accessKeyID = AppConfig.GetString(minioAccessKeyProp)
+	secretAccessKey = AppConfig.GetString(minioSecretAccessKeyProp)
+	useSSL = AppConfig.GetBool(minioUseSSLProp)
+	region = AppConfig.GetString(minioRegionProp)
+}
+
+func GetMinioClient() *minio.Client {
+	if minioClient == nil {
+		var err error
+		minioClient, err = minio.New(endpoint, &minio.Options{
+			Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+			Secure: useSSL,
+			Region: region,
+		})
+		if err != nil {
+			panic("failed to connect minio")
+		}
+	}
+
+	return minioClient
+}

--- a/packages/mapper/problem.go
+++ b/packages/mapper/problem.go
@@ -1,8 +1,15 @@
 package mapper
 
 import (
+	"context"
+	"io/fs"
+	"log"
+	"path/filepath"
+	"strings"
+
 	"github.com/OJ-lab/oj-lab-services/packages/application"
 	"github.com/OJ-lab/oj-lab-services/packages/model"
+	"github.com/minio/minio-go/v7"
 )
 
 func CreateProblem(problem model.Problem) error {
@@ -100,4 +107,43 @@ func GetTagsList(problem model.Problem) []string {
 		tagsList = append(tagsList, tag.Slug)
 	}
 	return tagsList
+}
+
+func PutProblemPackage(slug string, pkgDir string) error {
+	ctx := context.Background()
+	minioClient := application.GetMinioClient()
+
+	// remove old package
+	objectsCh := minioClient.ListObjects(ctx, application.GetBucketName(), minio.ListObjectsOptions{
+		Prefix:    slug,
+		Recursive: true,
+	})
+	for objInfo := range objectsCh {
+		if objInfo.Err != nil {
+			return objInfo.Err
+		}
+
+		err := minioClient.RemoveObject(ctx, application.GetBucketName(), objInfo.Key, minio.RemoveObjectOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	filepath.Walk(pkgDir, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		relativePath := filepath.Join(slug, strings.Replace(path, pkgDir, "", 1))
+
+		_, minioErr := minioClient.FPutObject(ctx, application.GetBucketName(),
+			relativePath,
+			path,
+			minio.PutObjectOptions{})
+		if minioErr != nil {
+			log.Fatalln(minioErr)
+		}
+		return minioErr
+	})
+
+	return nil
 }

--- a/service/problem/problem.go
+++ b/service/problem/problem.go
@@ -2,19 +2,18 @@ package problem
 
 import (
 	"github.com/OJ-lab/oj-lab-services/packages/mapper"
-	"github.com/OJ-lab/oj-lab-services/packages/utils"
 	"github.com/gin-gonic/gin"
 )
 
-func GetProblemInfo(c *gin.Context) {
-	slug := c.Param("slug")
+func GetProblemInfo(ctx *gin.Context) {
+	slug := ctx.Param("slug")
 	problem, err := mapper.GetProblem(slug)
 	if err != nil {
-		utils.ApplyError(c, err)
+		ctx.Error(err)
 		return
 	}
 
-	c.JSON(200, gin.H{
+	ctx.JSON(200, gin.H{
 		"slug":        problem.Slug,
 		"title":       problem.Title,
 		"description": problem.Description,

--- a/service/problem/problem.go
+++ b/service/problem/problem.go
@@ -1,6 +1,11 @@
 package problem
 
 import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+
 	"github.com/OJ-lab/oj-lab-services/packages/mapper"
 	"github.com/gin-gonic/gin"
 )
@@ -19,4 +24,69 @@ func GetProblemInfo(ctx *gin.Context) {
 		"description": problem.Description,
 		"tags":        mapper.GetTagsList(problem),
 	})
+}
+
+func PutProblemPackage(ctx *gin.Context) {
+	slug := ctx.Param("slug")
+	file, err := ctx.FormFile("file")
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	zipFile := "/tmp/" + slug + ".zip"
+	if err := ctx.SaveUploadedFile(file, zipFile); err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	// unzip package
+	targetDir := "/tmp/" + slug
+	err = os.RemoveAll(targetDir)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	r, err := zip.OpenReader(zipFile)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		rc, err := f.Open()
+		if err != nil {
+			ctx.Error(err)
+			return
+		}
+		defer rc.Close()
+
+		path := filepath.Join(targetDir, f.Name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, os.ModePerm)
+		} else {
+			if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+				ctx.Error(err)
+				return
+			}
+			outFile, err := os.Create(path)
+			if err != nil {
+				ctx.Error(err)
+				return
+			}
+			defer outFile.Close()
+			_, err = io.Copy(outFile, rc)
+			if err != nil {
+				ctx.Error(err)
+				return
+			}
+		}
+	}
+
+	// put package to minio
+	err = mapper.PutProblemPackage(slug, targetDir)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	ctx.Done()
 }

--- a/service/router/setup.go
+++ b/service/router/setup.go
@@ -23,6 +23,7 @@ func SetupProblemRoute(r *gin.Engine) {
 			c.String(http.StatusOK, "Hello, this is problem service")
 		})
 		g.GET("/:slug", problem.GetProblemInfo)
+		g.PUT("/:slug/package", problem.PutProblemPackage)
 		g.POST("/:slug/judge", problem.Judge)
 	}
 }

--- a/tests/minio_test.go
+++ b/tests/minio_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/minio/minio-go/v7"
 	"github.com/OJ-lab/oj-lab-services/packages/application"
+	"github.com/minio/minio-go/v7"
 )
 
 func TestMinio(T *testing.T) {
@@ -16,9 +16,7 @@ func TestMinio(T *testing.T) {
 	minioClient := application.GetMinioClient()
 
 	log.Printf("%#v\n", minioClient) // minioClient is now set up
-
-	// Make a new bucket called mymusic.
-	bucketName := "oj-lab-problem-packages"
+	bucketName := application.GetBucketName()
 
 	err := minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
 	if err != nil {

--- a/tests/minio_test.go
+++ b/tests/minio_test.go
@@ -8,30 +8,19 @@ import (
 	"testing"
 
 	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/OJ-lab/oj-lab-services/packages/application"
 )
 
 func TestMinio(T *testing.T) {
-	endpoint := "localhost:9000"
-	accessKeyID := "minio-root-user"
-	secretAccessKey := "minio-root-password"
-	useSSL := false
-
 	// Initialize minio client object.
-	minioClient, err := minio.New(endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
-		Secure: useSSL,
-	})
-	if err != nil {
-		log.Fatalln(err)
-	}
+	minioClient := application.GetMinioClient()
 
 	log.Printf("%#v\n", minioClient) // minioClient is now set up
 
 	// Make a new bucket called mymusic.
 	bucketName := "oj-lab-problem-packages"
 
-	err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
+	err := minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
 	if err != nil {
 		// Check to see if we already own this bucket (which happens if you run this twice)
 		exists, errBucketExists := minioClient.BucketExists(ctx, bucketName)


### PR DESCRIPTION
Now, we can add a problem package to minio by uploading an zip file through `PUT /api/v1/problem/:slug/package`

Notice that the `minioClient` is persistent now.